### PR TITLE
バックグラウンドでフォルダ要領計算

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ import constants
 import DefaultSettings
 import errorCodes
 import misc
+import workerThreads
 from views import main
 
 class falconAppMain(wx.App):
@@ -28,6 +29,7 @@ class falconAppMain(wx.App):
 		self.InitTranslation()
 		self.InitSound()
 		self.InitCaches()
+		workerThreads.Start()
 
 		# 起動サウンドの再生
 		self.PlaySound(self.config["sounds"]["startup"])

--- a/app.py
+++ b/app.py
@@ -118,3 +118,8 @@ class falconAppMain(wx.App):
 			return
 		#end error
 		pybass.BASS_ChannelPlay(handle,True)
+
+	def OnExit(self):
+		workerThreads.Stop()
+		return wx.App.OnExit(self)
+

--- a/misc.py
+++ b/misc.py
@@ -8,6 +8,9 @@ import os
 import time
 import win32api
 import win32file
+from logging import getLogger
+
+log=getLogger("falcon.misc")
 
 falconHelper=ctypes.cdll.LoadLibrary("falconHelper.dll")
 
@@ -116,10 +119,16 @@ def IteratePaths(path):
 def GetDirectorySize(path):
 	"""ディレクトリのサイズをバイト数で返す。"""
 	total = 0
-	with os.scandir(path) as it:
-		for entry in it:
-			if entry.is_file():
-				total += entry.stat().st_size
-			elif entry.is_dir():
-				total+=GetDirectorySize(entry.path)
+	try:
+		with os.scandir(path) as it:
+			for entry in it:
+				if entry.is_file():
+					total += entry.stat().st_size
+				elif entry.is_dir():
+					total+=GetDirectorySize(entry.path)
+
+	except OSError as er:
+		log.error("GetDirectorySize failed (%s" % er)
+		total=-1
+	#end except
 	return total

--- a/misc.py
+++ b/misc.py
@@ -113,3 +113,13 @@ def IteratePaths(path):
 		#end ディレクトリ
 		yield os.path.join(path,elem[8])
 
+def GetDirectorySize(path):
+	"""ディレクトリのサイズをバイト数で返す。"""
+	total = 0
+	with os.scandir(path) as it:
+		for entry in it:
+			if entry.is_file():
+				total += entry.stat().st_size
+			elif entry.is_dir():
+				total += get_dir_size(entry.path)
+	return total

--- a/misc.py
+++ b/misc.py
@@ -121,5 +121,5 @@ def GetDirectorySize(path):
 			if entry.is_file():
 				total += entry.stat().st_size
 			elif entry.is_dir():
-				total += get_dir_size(entry.path)
+				total+=GetDirectorySize(entry.path)
 	return total

--- a/tabObjects.py
+++ b/tabObjects.py
@@ -542,4 +542,4 @@ class MainListTab(FalconTabBase):
 	def _dirCalc_receive(self,results):
 		"""DirCalc の結果を受ける。"""
 		for elem in results:
-			self.hListCtrl.SetItem(index=elem[0],column=1,label=str(elem[1]))
+			self.hListCtrl.SetItem(index=elem[0],column=1,label=elem[1])

--- a/tabObjects.py
+++ b/tabObjects.py
@@ -536,5 +536,10 @@ class MainListTab(FalconTabBase):
 				lst.append((i,elem.fullpath))
 			#end フォルダだったら
 		#end for
-		param={'lst': lst}
+		param={'lst': lst, 'callback': self._dirCalc_receive}
 		workerThreads.RegisterTask(workerThreadTasks.DirCalc,param)
+
+	def _dirCalc_receive(self,results):
+		"""DirCalc の結果を受ける。"""
+		for elem in results:
+			self.hListCtrl.SetItem(index=elem[0],column=1,label=str(elem[1]))

--- a/tabObjects.py
+++ b/tabObjects.py
@@ -22,6 +22,7 @@ import globalVars
 import constants
 import fileOperator
 import misc
+import workerThreadTasks
 
 from simpleDialog import *
 from win32com.shell import shell, shellcon
@@ -72,17 +73,21 @@ class FalconTabBase(object):
 	def GetSelectedItemCount(self):
 		return self.hListCtrl.GetSelectedItemCount()
 
-	def GetSelectedItems(self):
-		"""選択中のアイテムを、 List オブジェクトで帰す。"""
+	def GetSelectedItems(self,index_mode=False):
+		"""選択中のアイテムを、 ListObject で帰す。index_mode が true の場合、 リスト上での index のリストを返す。"""
 		next=self.hListCtrl.GetFirstSelected()
 		if next==-1: return None
 		lst=[]
 		while(True):
-			lst.append(self.listObject.GetElement(next))
+			if index_mode:
+				lst.append(next)
+			else:
+				lst.append(self.listObject.GetElement(next))
 			next=self.hListCtrl.GetNextSelected(next)
 			if next==-1: break
 		#end while
 		#リストを作る
+		if index_mode: return lst
 		r=type(self.listObject)()
 		r.Initialize(lst)
 		return r
@@ -523,9 +528,13 @@ class MainListTab(FalconTabBase):
 
 	def DirCalc(self):
 		lst=[]
-		for elem in self.GetSelectedItems():
+		for i in self.GetSelectedItems(index_mode=True):
+			elem=self.listObject.GetElement(i)
 			if elem.__class__.__name__=="Folder":
-				lst.append(elem.fullpath)
+				self.hListCtrl.SetItem(index=i,column=1,label=_("<計算中>"))
+				lst.append((i,elem.fullpath))
 			#end フォルダだったら
 		#end for
-		print(misc.GetDirectorySize(lst[0]))
+		param={'lst': lst}
+
+

--- a/tabObjects.py
+++ b/tabObjects.py
@@ -22,6 +22,7 @@ import globalVars
 import constants
 import fileOperator
 import misc
+import workerThreads
 import workerThreadTasks
 
 from simpleDialog import *
@@ -536,5 +537,4 @@ class MainListTab(FalconTabBase):
 			#end フォルダだったら
 		#end for
 		param={'lst': lst}
-
-
+		workerThreads.RegisterTask(workerThreadTasks.DirCalc,param)

--- a/tabObjects.py
+++ b/tabObjects.py
@@ -521,3 +521,11 @@ class MainListTab(FalconTabBase):
 		globalVars.app.say(_("マーク位置へ移動"))
 		return errorCodes.OK
 
+	def DirCalc(self):
+		lst=[]
+		for elem in self.GetSelectedItems():
+			if elem.__class__.__name__=="Folder":
+				lst.append(elem.fullpath)
+			#end フォルダだったら
+		#end for
+		print(misc.GetDirectorySize(lst[0]))

--- a/views/main.py
+++ b/views/main.py
@@ -137,6 +137,8 @@ class Menu(BaseMenu):
 		self.RegisterMenuCommand(self.hMoveMenu,"MOVE_TOPFILE",_("先頭ファイルへ"))
 		self.RegisterMenuCommand(self.hMoveMenu,"MOVE_MARKSET",_("表示中の場所をマーク"))
 		self.RegisterMenuCommand(self.hMoveMenu,"MOVE_MARK",_("マークした場所へ移動"))
+		#ツールメニューの中身
+		self.RegisterMenuCommand(self.hToolMenu,"TOOL_DIRCALC",_("フォルダ容量計算"))
 
 		#環境メニューの中身
 		self.RegisterMenuCommand(self.hEnvMenu,"ENV_TESTDIALOG",_("テストダイアログを表示"))

--- a/views/main.py
+++ b/views/main.py
@@ -260,6 +260,9 @@ class Events(BaseEvents):
 			if self.parent.activeTab.IsItemSelected():
 				self.parent.activeTab.ShowProperties()
 			return
+		if selected==menuItemsStore.getRef("TOOL_DIRCALC"):
+			self.parent.activeTab.DirCalc()
+			return
 		if selected==menuItemsStore.getRef("ENV_TESTDIALOG"):
 			self.testdialog=views.test.View()
 			self.testdialog.Initialize()

--- a/workerThreadTasks.py
+++ b/workerThreadTasks.py
@@ -1,0 +1,18 @@
+﻿# -*- coding: utf-8 -*-
+#Falcon worker thread tasks
+#Copyright (C) 2019 Yukio Nozawa <personal@nyanchangames.com>
+#Note: All comments except these top lines will be written in Japanese. 
+
+"""
+ワーカースレッドで実行されるタスクは、ここに並べます。ワーカースレッドのタスクは、必ず param という辞書を引数にとり、それを使って処理します。
+"""
+
+import misc
+
+def DirCalc(param):
+	lst=param['lst']
+	total=0
+	for elem in lst:
+		total+=misc.GetDirectorySize(elem[1])
+	#end for
+	print(total)

--- a/workerThreadTasks.py
+++ b/workerThreadTasks.py
@@ -15,6 +15,11 @@ def DirCalc(param):
 	lst=param['lst']
 	results=[]
 	for elem in lst:
-		results.append((elem[0],misc.GetDirectorySize(elem[1])))
+		s=misc.GetDirectorySize(elem[1])
+		if s==-1:
+			results.append((elem[0],_("<取得失敗>")))
+		else:
+			results.append((elem[0],misc.ConvertBytesTo(s,misc.UNIT_AUTO,True)))
+		#end 成功か失敗か
 	#end for
 	wx.CallAfter(param['callback'],results)

--- a/workerThreadTasks.py
+++ b/workerThreadTasks.py
@@ -7,12 +7,14 @@
 ワーカースレッドで実行されるタスクは、ここに並べます。ワーカースレッドのタスクは、必ず param という辞書を引数にとり、それを使って処理します。
 """
 
+import wx
+
 import misc
 
 def DirCalc(param):
 	lst=param['lst']
-	total=0
+	results=[]
 	for elem in lst:
-		total+=misc.GetDirectorySize(elem[1])
+		results.append((elem[0],misc.GetDirectorySize(elem[1])))
 	#end for
-	print(total)
+	wx.CallAfter(param['callback'],results)

--- a/workerThreads.py
+++ b/workerThreads.py
@@ -1,0 +1,62 @@
+﻿# -*- coding: utf-8 -*-
+#Falcon background thread manager
+#Copyright (C) 2019 Yukio Nozawa <personal@nyanchangames.com>
+#Note: All comments except these top lines will be written in Japanese. 
+
+"""
+Falcon は、ワーカースレッドを提供します。ワーカースレッドに関数と引数を渡せば、バックグラウンドで実行してくれます。
+"""
+
+import logging
+from logging import getLogger
+import queue
+import threading
+
+tasks=queue.Queue()
+
+class _workerThreadBody(threading.Thread):
+	def __init__(self):
+		threading.Thread.__init__(self)
+		self.cancellable=True
+
+	def run():
+		while(True):
+			item=tasks.get()
+			if isinstance(item,str) and item=="exit":#ワーカースレッド終了
+				tasks.task_done()
+				break
+			#end 終了
+			func=item[0]
+			params=item[1]
+			func(params)
+			tasks.task_done()
+		#end while
+	#end run
+
+initialized=False
+
+threads=[]
+
+def Start(worker_num=2):
+	"""ワーカースレッドの数を指定して、初期化を行う。"""
+	global initialized, log
+	if initialized: return
+	initialized=True
+	log=getLogger("falcon.workerThreads")
+	log.debug("%d worker threads initialized." % worker_num)
+	for  i in range(worker_num):
+		t=_workerThreadBody()
+		t.setDaemon(True)
+		threads.append(t)
+	#end for
+#end Initialize
+
+def Stop():
+	"""全てのワーカースレッドを停止させる。"""
+	for elem in threads:
+		elem.join()
+
+def register(func,param):
+	"""関数とパラメータを指定して、ワーカースレッドに処理を任せる。"""
+	log.debug("register")
+	tasks.put((func,param))

--- a/workerThreads.py
+++ b/workerThreads.py
@@ -15,14 +15,17 @@ import threading
 tasks=queue.Queue()
 
 class _workerThreadBody(threading.Thread):
-	def __init__(self):
+	def __init__(self,identifier):
 		threading.Thread.__init__(self)
 		self.cancellable=True
+		self.log=getLogger("falcon.workerThread%d" % identifier)
 
-	def run():
+	def run(self):
 		while(True):
 			item=tasks.get()
-			if isinstance(item,str) and item=="exit":#ワーカースレッド終了
+			self.log.debug("picked up job")
+			if isinstance(item,str) and item=="stop":#ワーカースレッド終了
+				self.log.debug("Received stop signal. Exiting thread...")
 				tasks.task_done()
 				break
 			#end 終了
@@ -45,18 +48,22 @@ def Start(worker_num=2):
 	log=getLogger("falcon.workerThreads")
 	log.debug("%d worker threads initialized." % worker_num)
 	for  i in range(worker_num):
-		t=_workerThreadBody()
-		t.setDaemon(True)
+		t=_workerThreadBody(i+1)
+		t.start()
 		threads.append(t)
 	#end for
 #end Initialize
 
 def Stop():
 	"""全てのワーカースレッドを停止させる。"""
+	log.debug("Stopping worker threads...")
+	for i in range(len(threads)):
+		tasks.put("stop")
 	for elem in threads:
 		elem.join()
+	log.debug("Stopped")
 
-def register(func,param):
+def RegisterTask(func,param):
 	"""関数とパラメータを指定して、ワーカースレッドに処理を任せる。"""
 	log.debug("register")
 	tasks.put((func,param))

--- a/workerThreads.py
+++ b/workerThreads.py
@@ -33,6 +33,7 @@ class _workerThreadBody(threading.Thread):
 			params=item[1]
 			func(params)
 			tasks.task_done()
+			self.log.debug("task finished.")
 		#end while
 	#end run
 


### PR DESCRIPTION
ツールメニューから「フォルダ要領計算」をすることで、選択中（複数同時でも可）のフォルダのサイズを計算することができます。
バックグラウンドで実行されます。今後使うかなぁと思ったので、ワーカースレッドに処理をさせるためのモジュールを書きました。
今のところ、計算中にディレクトリ移動をするとバグる可能性があります、というか、バグります。まだ、ワーカースレッドに頼んだ仕事を中断させる気候がないので、そのうち考えます。お正月ぐらいには。