### PR TITLE
削除のファイルオペレーターがcommonFailureを通っていなくて、失敗アイテムが取得できてなかった

### DIFF
--- a/fileOperator/delete.py
+++ b/fileOperator/delete.py
@@ -44,7 +44,7 @@ def Execute(op):
 			else:
 				win32file.RemoveDirectory(elem)
 		except win32file.error as err:
-			appendRetry(op.output,elem)
+			if helper.CommonFailure(op,elem,err,log): appendRetry(op.output,elem)
 			continue
 		#end except
 		op.output["succeeded"]+=1


### PR DESCRIPTION
これで、 #142 を閉じていいんでないかな。