### PR TITLE
ファイルプレビューをdelaied callで呼ばない

### DIFF
--- a/views/main.py
+++ b/views/main.py
@@ -512,7 +512,7 @@ class Events(BaseEvents):
 			self.DelaiedCall(self.parent.activeTab.ReadListInfo)
 			return
 		if selected==menuItemsStore.getRef("READ_CONTENT_PREVIEW"):
-			self.DelaiedCall(self.parent.activeTab.Preview)
+			self.parent.activeTab.Preview()
 			return
 		if selected==menuItemsStore.getRef("READ_CONTENT_READHEADER"):
 			self.DelaiedCall(self.parent.activeTab.ReadHeader)


### PR DESCRIPTION
デフォルトのコマンドがshift+returnなので、エンターが押されてるってことになり、メニューの外から実行しても遅延してしまう。別の仕組みを考える予定。