### PR TITLE
ドライブリストでコンテキストメニューが表示されるようにする（独自メニュー）

### DIFF
--- a/tabs/driveList.py
+++ b/tabs/driveList.py
@@ -135,3 +135,12 @@ class DriveListTab(base.FalconTabBase):
 	def GetTabName(self):
 		"""タブコントロールに表示する名前"""
 		return _("ドライブ一覧")
+
+	def OpenContextMenu(self,event):
+		menu=wx.Menu()
+		globalVars.app.hMainView.menu.RegisterMenuCommand(menu,{
+			"TOOL_EJECT_DRIVE":_("ドライブの取り外し"),
+			"TOOL_EJECT_DEVICE":_("デバイスの取り外し"),
+			"FILE_SHOWPROPERTIES":_("プロパティを表示")
+		})
+		globalVars.app.hMainView.PopupMenu(menu)

--- a/views/base.py
+++ b/views/base.py
@@ -47,6 +47,9 @@ class BaseView(object):
 		self.SetShortcutEnable=en
 	#end SetShortcutEnabled
 
+	def PopupMenu(self,hMenu):
+		self.hFrame.PopupMenu(hMenu)
+
 class BaseMenu(object):
 	def __init__(self):
 		self.blockCount={}


### PR DESCRIPTION
とりあえず、ディスク/ドライブの取り外しとプロパティだけ入れてあります。他に入れたい項目があったら、その都度入れる感じで。
たぶん、複数選択しているときに無効化するとか、その辺はやっていません。