### PR TITLE
fixed #316 ,code optimisation

### DIFF
--- a/browsableObjects.py
+++ b/browsableObjects.py
@@ -105,6 +105,23 @@ class Folder(File):
 		else:
 			return (self.basename, misc.ConvertBytesTo(self.size,misc.UNIT_AUTO,True), misc.PTime2string(self.modDate), self.attributesString, self.typeString)
 
+class SearchedFile(File):
+	__slots__=[]
+
+	def GetListTuple(self):
+		"""表示に必要なタプルを返す。"""
+		return (self.basename, misc.ConvertBytesTo(self.size,misc.UNIT_AUTO,True), self.fullpath, misc.PTime2string(self.modDate), self.attributesString, self.typeString)
+
+class SearchedFolder(Folder):
+	__slots__=[]
+
+	def GetListTuple(self):
+		"""表示に必要なタプルを返す。フォルダなのでサイズ不明(-1)の場合があり、この場合は <dir> にする。"""
+		if self.size<0:
+			return (self.basename, "<dir>", self.fullpath, misc.PTime2string(self.modDate), self.attributesString, self.typeString)
+		else:
+			return (self.basename, misc.ConvertBytesTo(self.size,misc.UNIT_AUTO,True), self.fullpath, misc.PTime2string(self.modDate), self.attributesString, self.typeString)
+
 class GrepItem(File):
 	def Initialize(self,ln,preview,fileobject):
 		"""grepの結果は、ファイルの情報に加えて、行数・プレビュー・ヒット数を含む。ヒット数は、後から設定する。ファイル名などは、与えられたファイルオブジェクトからとる。"""
@@ -120,6 +137,7 @@ class GrepItem(File):
 		self.ln=ln
 		self.preview=preview
 		self.hits=0#とりあえず入れておく
+		self.hIcon=fileobject.hIcon
 
 	def SetHitCount(self,h):
 		"""ヒット数を設定する。"""

--- a/lists/base.py
+++ b/lists/base.py
@@ -121,9 +121,6 @@ class FalconListBase(object):
 				return int(math.log10(self.GetElement(index).total))	#サイズの桁数
 			except ValueError:	#ネットワークリソースなどサイズが未定義の場合に発生
 				return -1
-		elif sortType == SORT_TYPE_SEARCHPATH:
-			#return self.GetElement(index).searchPath				#最初の1文字
-			return ""
 		else:
 			print (self._getSortFunction(sortType)(self.GetElement(index)))
 			return self._getSortFunction(sortType)(self.GetElement(index))
@@ -189,6 +186,7 @@ class FalconListBase(object):
 		if attrib==SORT_TYPE_DRIVELETTER: return lambda x: x.letter
 		if attrib==SORT_TYPE_FREESPACE: return lambda x: x.free
 		if attrib==SORT_TYPE_TOTALSPACE: return lambda x: x.total
+		if attrib==SORT_TYPE_SEARCHPATH: return lambda x: x.fullpath.lower()
 		if attrib==SORT_TYPE_HITCOUNT: return lambda x: x.hits
 		if attrib==SORT_TYPE_HITLINE: return lambda x: x.ln
 		if attrib==SORT_TYPE_PREVIEW: return lambda x: x.preview.lower()

--- a/lists/searchResult.py
+++ b/lists/searchResult.py
@@ -46,7 +46,7 @@ class SearchResultList(FalconListBase):
 		"""与えられたファイル名のリストから、条件に一致する項目を抽出する。"""
 		if isinstance(rootDirectory,list):#パラメータがリストなら、browsableObjects のリストとして処理刷る(ファイルリストを取得しないでコピーする)
 			for elem in rootDirectory:
-				if type(elem) is browsableObjects.Folder:
+				if type(elem) is browsableObjects.SearchedFolder:
 					self.folders.append(elem)
 				else:
 					self.files.append(elem)
@@ -103,12 +103,12 @@ class SearchResultList(FalconListBase):
 				creation=datetime.datetime.fromtimestamp(stat.st_ctime)
 				ret, shfileinfo=shell.SHGetFileInfo(fullpath,0,shellcon.SHGFI_ICON|shellcon.SHGFI_TYPENAME)
 				if os.path.isfile(fullpath):
-					f=browsableObjects.File()
+					f=browsableObjects.SearchedFile()
 					f.Initialize(os.path.dirname(fullpath),os.path.basename(fullpath),fullpath,stat.st_size,mod,win32file.GetFileAttributes(fullpath),shfileinfo[4],creation,win32api.GetShortPathName(fullpath))
 					self.files.append(f)
 					ret_list.append(f)
 				else:
-					f=browsableObjects.Folder()
+					f=browsableObjects.SearchedFolder()
 					f.Initialize(os.path.dirname(fullpath),os.path.basename(fullpath),fullpath,-1,mod,win32file.GetFileAttributes(fullpath),shfileinfo[4],creation,win32api.GetShortPathName(fullpath))
 					self.folders.append(f)
 					ret_list.append(f)

--- a/tabs/base.py
+++ b/tabs/base.py
@@ -100,6 +100,11 @@ class FalconTabBase(object):
 		"TOOL_EJECT_DRIVE",
 		"TOOL_EJECT_DEVICE"
 	])
+
+	#それぞれFile・Folderと同期
+	selectItemTypeMenuConditions[browsableObjects.SearchedFile]=selectItemTypeMenuConditions[browsableObjects.File]
+	selectItemTypeMenuConditions[browsableObjects.SearchedFolder]=selectItemTypeMenuConditions[browsableObjects.Folder]
+
 	#以下３つは専用のタブになってるのでこの機能でやる必要はない。KeyErrorにならないようにしとくだけ。
 	selectItemTypeMenuConditions[browsableObjects.GrepItem]=[]
 	selectItemTypeMenuConditions[browsableObjects.Drive]=[]
@@ -581,7 +586,7 @@ class FalconTabBase(object):
 		"""選択中のフォルダやドライブに入るか、選択中のファイルを実行する。stream=True の場合、ファイルの NTFS 副ストリームを開く。"""
 		index=self.GetFocusedItem()
 		elem=self.listObject.GetElement(index)
-		if (not stream) and (type(elem)==browsableObjects.File or type(elem)==browsableObjects.GrepItem) :#このファイルを開く
+		if (not stream) and (type(elem)==browsableObjects.File):	#このファイルを開く
 			misc.RunFile(elem.fullpath,admin)
 			return
 		else:
@@ -855,7 +860,7 @@ class FalconTabBase(object):
 				self.hilightIndex=-1
 		elif self.hilightIndex != index:
 			self.hListCtrl.SetItemState(self.hilightIndex,0,wx.LIST_STATE_DROPHILITED)
-			if type(self.listObject.GetElement(index)) in (browsableObjects.Folder,browsableObjects.Drive):
+			if isinstance(self.listObject.GetElement(index),(browsableObjects.Folder,browsableObjects.Drive)):
 				self.hListCtrl.SetItemState(index,wx.LIST_STATE_DROPHILITED,wx.LIST_STATE_DROPHILITED)
 				self.hilightIndex=index
 			else:
@@ -943,7 +948,7 @@ class DropTarget(wx.DropTarget):
 		i,flg=self.parent.hListCtrl.HitTest((x,y))
 		if flg & wx.LIST_HITTEST_ONITEM !=0:
 			index=i
-		if index>=0 and type(self.parent.listObject.GetElement(index)) in (browsableObjects.Folder,browsableObjects.Drive):
+		if index>=0 and isinstance(self.parent.listObject.GetElement(index),(browsableObjects.Folder,browsableObjects.Drive)):
 			#カーソルのあるオブジェクトの中に入れる
 			dest=self.parent.listObject.GetElement(index).fullpath
 		else:

--- a/tabs/searchResult.py
+++ b/tabs/searchResult.py
@@ -8,112 +8,23 @@
 検索結果が格納されていきます。一通りのファイル操作を行うことができます。
 """
 
-import os
-import gettext
-import logging
-import wx
-import errorCodes
-import lists
-import browsableObjects
 import globalVars
-import misc
-import workerThreads
-import workerThreadTasks
-import StringUtil
+import lists
 
-from win32com.shell import shell, shellcon
-from . import fileList
+from . import searchResultTabBase
 
-class SearchResultTab(fileList.FileListTab):
+
+class SearchResultTab(searchResultTabBase.SearchResultTabBase):
 	"""検索結果が表示されているタブ。"""
 
-	blockMenuList=[
-		"FILE_MKDIR",
-		"EDIT_PAST",
-		"EDIT_SEARCH",
-		"MOVE_BACKWARD",
-		"MOVE_MARKSET",
-		"MOVE_MARK",
-		"VIEW_DRIVE_INFO",
-		"TOOL_ADDPATH",
-		"TOOL_EJECT_DRIVE",
-		"TOOL_EJECT_DEVICE",
-		"TOOL_EXEC_PROGRAM"
+	blockMenuList=searchResultTabBase.SearchResultTabBase.blockMenuList+[
 	]
 
-	def StartSearch(self,rootPath,searches,keyword, isRegularExpression):
-		self.listObject=lists.SearchResultList()
-		self.listObject.Initialize(rootPath,searches,keyword, isRegularExpression)
-		self.SetListColumns(self.listObject)
-		workerThreads.RegisterTask(workerThreadTasks.PerformSearch,{'listObject': self.listObject, 'tabObject': self})
-
-		#タブの名前変更を通知
-		globalVars.app.hMainView.UpdateTabName()
-
-	def _onSearchHitCallback(self,hits):
-		"""コールバックで、ヒットした browsableObject のリストが降ってくるので、それをリストビューに追加していく。"""
-		globalVars.app.PlaySound("click.ogg")
-		for elem in hits:
-			t=elem.GetListTuple()
-			if type(elem) is browsableObjects.File:
-				self.hListCtrl.Append((t[0],t[1],elem.fullpath,t[2],t[3],t[4]))
-			else:
-				idx=0
-				self.hListCtrl.InsertItem(idx,t[0])
-				self.hListCtrl.SetItem(idx,1,t[1])
-				self.hListCtrl.SetItem(idx,2,elem.fullpath)
-				self.hListCtrl.SetItem(idx,3,t[2])
-				self.hListCtrl.SetItem(idx,4,t[3])
-				self.hListCtrl.SetItem(idx,5,t[4])
-		#end 追加
-		if self.listObject.GetFinishedStatus():
-			self.listObject.ApplySort()
-			self.hListCtrl.DeleteAllItems()
-			self.UpdateListContent(self.listObject.GetItems())
+	#内部で利用するリストの種類を定義
+	listType = lists.SearchResultList
 
 	#TODO:GoToTopFile(self):
-
-	def GoBackward(self):
-		return errorCodes.BOUNDARY
-
-	def ReadCurrentFolder(self):
-		state=_("検索完了") if self.listObject.GetFinishedStatus() is True else _("検索中")
-		globalVars.app.say(_("キーワード %(keyword)s で ディレクトリ %(dir)s を%(state)s") % {'keyword': self.listObject.GetKeywordString(), 'dir': self.listObject.rootDirectory, 'state': state}, interrupt=True)
-
-	def ReadListItemNumber(self,short=False):
-		globalVars.app.say(_("検索結果 %(results)d件") % {'results': len(self.listObject)}, interrupt=True)
 
 	def ReadListInfo(self):
 		globalVars.app.say(_("%(keyword)sの検索結果を %(sortkind)sの%(sortad)sで一覧中、 %(max)d個中 %(current)d個目") %{'keyword': self.listObject.GetKeywordString(), 'sortkind': self.listObject.GetSortKindString(), 'sortad': self.listObject.GetSortAdString(), 'max': len(self.listObject), 'current': self.GetFocusedItem()+1}, interrupt=True)
 
-	def GoForward(self,stream,admin=False):
-		"""検索結果表示では、フォルダを開くときに別タブを生成する。"""
-		index=self.GetFocusedItem()
-		elem=self.listObject.GetElement(index)
-		if (not stream) and (type(elem)==browsableObjects.File or type(elem)==browsableObjects.GrepItem) :#このファイルを開く
-			misc.RunFile(elem.fullpath,admin)
-			return
-		else:
-			#新しいタブで開く
-			globalVars.app.hMainView.Navigate(elem.fullpath,as_new_tab=True)
-		#end ファイルを開くか移動するか
-	#end GoForward
-
-	def UpdateFilelist(self,silence=False,cursorTargetName=""):
-		"""検索をやり直す。ファイルは非同期処理で増えるので、cursorTargetNameは使用されない。"""
-		if not self.listObject.GetFinishedStatus():
-			globalVars.app.say(_("現在検索中です。再建策はできません。"), interrupt=True)
-			return
-		#end まだ検索終わってない
-		if silence==False:
-			globalVars.app.say(_("再建策"), interrupt=True)
-		#end not silence
-		self.hListCtrl.DeleteAllItems()
-		self.listObject.RedoSearch()
-		workerThreads.RegisterTask(workerThreadTasks.PerformSearch,{'listObject': self.listObject, 'tabObject': self})
-
-	def GetTabName(self):
-		"""タブコントロールに表示する名前"""
-		word=_("%(word)sの検索") % {"word":self.listObject.GetKeywordString()}
-		word=StringUtil.GetLimitedString(word,globalVars.app.config["view"]["header_title_length"])
-		return word

--- a/tabs/searchResultTabBase.py
+++ b/tabs/searchResultTabBase.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+#Falcon searchResultTabBase
+#Copyright (C) 2019-2020 Yukio Nozawa <personal@nyanchangames.com>
+#Copyright (C) 2019-2020 yamahubuki <itiro.ishino@gmail.com>
+#Note: All comments except these top lines will be written in Japanese. 
+
+"""
+	通常検索・ファイル内容検索共通の関数群
+"""
+
+import browsableObjects
+import errorCodes
+import globalVars
+import misc
+import StringUtil
+import tabs
+import workerThreads
+import workerThreadTasks
+
+class SearchResultTabBase(tabs.fileList.FileListTab):
+
+	blockMenuList=[
+		"FILE_MKDIR",
+		"EDIT_PAST",
+		"EDIT_SEARCH",
+		"MOVE_BACKWARD",
+		"MOVE_MARKSET",
+		"MOVE_MARK",
+		"VIEW_DRIVE_INFO",
+		"TOOL_ADDPATH",
+		"TOOL_EJECT_DRIVE",
+		"TOOL_EJECT_DEVICE",
+		"TOOL_EXEC_PROGRAM"
+	]
+
+	def StartSearch(self,rootPath,searches,keyword, isRegularExpression):
+		self.listObject=self.listType()
+		self.listObject.Initialize(rootPath,searches,keyword, isRegularExpression)
+		self.SetListColumns(self.listObject)
+		workerThreads.RegisterTask(workerThreadTasks.PerformSearch,{'listObject': self.listObject, 'tabObject': self})
+
+		#タブの名前変更を通知
+		globalVars.app.hMainView.UpdateTabName()
+
+	def _onSearchHitCallback(self,hits):
+		"""コールバックで、ヒットしたオブジェクトのリストが降ってくるので、それをリストビューに追加していく。"""
+		globalVars.app.PlaySound("click.ogg")
+		for elem in hits:
+			self.hListCtrl.Append(elem.GetListTuple())
+		#end 追加
+		if self.listObject.GetFinishedStatus():
+			self.listObject.ApplySort()
+			self.hListCtrl.DeleteAllItems()
+			self.UpdateListContent(self.listObject.GetItems())
+
+	def UpdateFilelist(self,silence=False,cursorTargetName=""):
+		"""検索をやり直す。ファイルは非同期処理で増えるので、cursorTargetNameは使用されない。"""
+		if not self.listObject.GetFinishedStatus():
+			globalVars.app.say(_("現在検索中です。再建策はできません。"), interrupt=True)
+			return
+		#end まだ検索終わってない
+		if silence==False:
+			globalVars.app.say(_("再建策"), interrupt=True)
+		#end not silence
+		self.hListCtrl.DeleteAllItems()
+		self.listObject.RedoSearch()
+		workerThreads.RegisterTask(workerThreadTasks.PerformSearch,{'listObject': self.listObject, 'tabObject': self})
+
+	def GoForward(self,stream,admin=False):
+		"""検索結果表示では、フォルダを開くときに別タブを生成する。"""
+		index=self.GetFocusedItem()
+		elem=self.listObject.GetElement(index)
+		if (not stream) and (not isinstance(elem,browsableObjects.Folder)): #このファイルを開く
+			misc.RunFile(elem.fullpath,admin)
+			return
+		else:
+			#新しいタブで開く
+			globalVars.app.hMainView.Navigate(elem.fullpath,as_new_tab=True)
+		#end ファイルを開くか移動するか
+	#end GoForward
+
+	def GoBackward(self):
+		return errorCodes.BOUNDARY
+
+	def ReadCurrentFolder(self):
+		state=_("検索完了") if self.listObject.GetFinishedStatus() is True else _("検索中")
+		globalVars.app.say(_("キーワード %(keyword)s で ディレクトリ %(dir)s を%(state)s") % {'keyword': self.listObject.GetKeywordString(), 'dir': self.listObject.rootDirectory, 'state': state}, interrupt=True)
+
+	def ReadListItemNumber(self,short=False):
+		globalVars.app.say(_("検索結果 %(results)d件") % {'results': len(self.listObject)}, interrupt=True)
+
+	def GetTabName(self):
+		"""タブコントロールに表示する名前"""
+		word=self.listObject.GetKeywordString()
+		word=StringUtil.GetLimitedString(word,globalVars.app.config["view"]["header_title_length"])
+		word=_("%(word)sの検索") % {"word":word}
+		return word

--- a/views/main.py
+++ b/views/main.py
@@ -425,7 +425,7 @@ class Events(BaseEvents):
 			return
 		if selected==menuItemsStore.getRef("MOVE_EXEC_ORIGINAL_ASSOCIATION"):
 			elem=self.parent.activeTab.GetFocusedElement()
-			if (not type(elem)==browsableObjects.Folder) and isinstance(elem,(browsableObjects.File,browsableObjects.Stream,browsableObjects.GrepItem)):
+			if (not isinstance(elem,browsableObjects.Folder)) and isinstance(elem,(browsableObjects.File,browsableObjects.Stream,browsableObjects.GrepItem)):
 				extention=os.path.splitext(elem.fullpath)[1][1:].lower()
 				if extention in globalVars.app.config["originalAssociation"]:
 					config=globalVars.app.config["originalAssociation"][extention]


### PR DESCRIPTION
・検索結果画面をソートするとカラム１つ消失する問題を解決する為、検索結果用のbrowsableObjectを2つ作りました。
・検索とgrepには共通点があまりにも多いので、重複コードを解決するためにSearchResultTabBaseを作ってまとめました。こいつはFileListTabを継承しています。
・不要なimport文は削除しました。
・上記変更に伴い、type()で判定してた数か所を継承を加味した判定に置き換えました。


検索結果画面でAltメニューを眺めて、いろいろやって、問題な下げだったらマージしてください。


