### PR TITLE
非同期処理で、 taskState.Cancel(wait=True) でタスクキャンセル待ちができるようにする

### DIFF
--- a/workerThreads.py
+++ b/workerThreads.py
@@ -4,13 +4,14 @@
 #Note: All comments except these top lines will be written in Japanese. 
 
 """
-Falcon は、ワーカースレッドを提供します。ワーカースレッドに関数と引数を渡せば、バックグラウンドで実行してくれます。
+Falcon は、ワーカースレッドを提供します。ワーカースレッドに workerThreadTasks で定義しているタスクと引数を渡せば、バックグラウンドで実行してくれます。
 """
 
 import logging
 from logging import getLogger
 import queue
 import threading
+import time
 import misc
 
 tasks=queue.Queue()
@@ -24,14 +25,27 @@ class TaskState(object):
 	def __init__(self,func,params,cancelable=True):
 		self.func=func
 		self.params=params
+		self.working=False
 		self.canceled=False
+		self.cancel_callback_done=False
 		self.cancelable=cancelable
 		self.finished=False
 
-	def Cancel(self):
+	def Cancel(self,wait=False):
+		"""タスクの実行を中断する。wait=Trueの場合、キャンセル処理がタスクに伝わり、実際に処理が終了するまでブロックする。"""
 		if not self.cancelable: return False
 		self.canceled=True
+		if self.working and wait:
+			while(self.cancel_callback_done is False): time.sleep(0.05)
 		return True
+
+	def CancelCallback(self):
+		"""ワーカースレッドからのコールバック。キャンセル処理が正常に完了し、スレッドが終了したことを通知する。"""
+		self.cancel_callback_done=True
+
+	def setWorkingState(self,w):
+		"""スレッドがタスクキューからこのタスクを拾って、実行を開始したときに呼び出すことで、状態が作業中になったことを知らせる。cancel(wait=True)メソッドで実行を待機する際、working=Trueかどうかで、実際に待つ処理をするかどうかを切り替えている。"""
+		self.working=w
 
 class _workerThreadBody(threading.Thread):
 	def __init__(self,identifier):
@@ -57,9 +71,12 @@ class _workerThreadBody(threading.Thread):
 			params=item.params
 			active_task_states.append(item)
 			t=misc.Timer()
+			item.setWorkingState(True)
 			ret=func(item,params)
+			if ret is False: item.CancelCallback()
 			tasks.task_done()
 			self.log.debug("task finished in %f seconds." % (t.elapsed) if ret else "Task canceled.")
+			item.setWorkingState(False)
 			active_task_states.remove(item)
 		#end while
 	#end run


### PR DESCRIPTION
タスクキャンセルを要求しても、きりのいいところでしかキャンセルしてくれない。
なので、キャンセル処理がスレッドに伝わって、実際に処理が中断されるまで待ちたい場面がある。
そうしないと、検索中にタブを閉じたりしたときに、タイミングによっては、削除したリストコントロールに項目を追加したりしちゃう。