### PR TITLE
Fix search probrems(2)

### DIFF
--- a/lists/file.py
+++ b/lists/file.py
@@ -18,10 +18,10 @@ from win32com.shell import shell, shellcon
 
 from simpleDialog import *
 
-from .base import *
+from .fileListBase import *
 from .constants import *
 
-class FileList(FalconListBase):
+class FileList(FileListBase):
 	"""ファイルとフォルダの一覧を扱うリスト。"""
 	def __init__(self):
 		super().__init__()
@@ -110,36 +110,6 @@ class FileList(FalconListBase):
 	def GetTopFileIndex(self):
 		"""先頭ファイルのインデックス番号を返す。"""
 		return len(self.folders)
-
-	def GetAttributeCheckState(self):
-		"""このリストに入っているファイルを1個ずつとって、対応するファイルの属性値を取得していく。各属性に対して、リスト内の全てのファイルが持っていれば ATTRIB_FULL_CHECKED を帰す。一部のファイルが持っていれば、 ATTRIB_HALF_CHECKED を帰す。どのファイルも持っていなければ、 ATTRIB_NOT_CHECKED を帰す。このデータを、リストにして帰す。"""
-		found=[0,0,0,0]#各属性を見つけた個数
-		ret=[constants.NOT_CHECKED, constants.NOT_CHECKED, constants.NOT_CHECKED, constants.NOT_CHECKED]#帰す値
-		for elem in self:
-			attrib=elem.attributes
-			if attrib&win32file.FILE_ATTRIBUTE_READONLY:
-				found[READONLY]+=1
-				ret[READONLY]=constants.HALF_CHECKED
-			#end readonly
-			if attrib&win32file.FILE_ATTRIBUTE_HIDDEN:
-				found[HIDDEN]+=1
-				ret[HIDDEN]=constants.HALF_CHECKED
-			#end hidden
-			if attrib&win32file.FILE_ATTRIBUTE_SYSTEM:
-				found[SYSTEM]+=1
-				ret[SYSTEM]=constants.HALF_CHECKED
-			#end system
-			if attrib&win32file.FILE_ATTRIBUTE_ARCHIVE:
-				found[ARCHIVE]+=1
-				ret[ARCHIVE]=constants.HALF_CHECKED
-			#end system
-		#end for
-		l=len(self)
-		if found[READONLY]==l: ret[READONLY]=constants.FULL_CHECKED
-		if found[HIDDEN]==l: ret[HIDDEN]=constants.FULL_CHECKED
-		if found[SYSTEM]==l: ret[SYSTEM]=constants.FULL_CHECKED
-		if found[ARCHIVE]==l: ret[ARCHIVE]=constants.FULL_CHECKED
-		return ret
 
 	def GetFolderFileNumber(self):
 		return len(self.folders), len(self.files)

--- a/lists/fileListBase.py
+++ b/lists/fileListBase.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#Falcon FileList Base Function
+#Copyright (C) 2019-2020 Yukio Nozawa <personal@nyanchangames.com>
+#Copyright (C) 2019-2020 yamahubuki <itiro.ishino@gmail.com>
+#Note: All comments except these top lines will be written in Japanese. 
+
+import win32file
+
+import constants
+
+from .base import FalconListBase
+
+class FileListBase(FalconListBase):
+	def __init__(self):
+		super().__init__()
+
+	def GetAttributeCheckState(self):
+		"""このリストに入っているファイルを1個ずつとって、対応するファイルの属性値を取得していく。各属性に対して、リスト内の全てのファイルが持っていれば ATTRIB_FULL_CHECKED を帰す。一部のファイルが持っていれば、 ATTRIB_HALF_CHECKED を帰す。どのファイルも持っていなければ、 ATTRIB_NOT_CHECKED を帰す。このデータを、リストにして帰す。"""
+		found=[0,0,0,0]#各属性を見つけた個数
+		ret=[constants.NOT_CHECKED, constants.NOT_CHECKED, constants.NOT_CHECKED, constants.NOT_CHECKED]#帰す値
+		for elem in self:
+			attrib=elem.attributes
+			if attrib&win32file.FILE_ATTRIBUTE_READONLY:
+				found[READONLY]+=1
+				ret[READONLY]=constants.HALF_CHECKED
+			#end readonly
+			if attrib&win32file.FILE_ATTRIBUTE_HIDDEN:
+				found[HIDDEN]+=1
+				ret[HIDDEN]=constants.HALF_CHECKED
+			#end hidden
+			if attrib&win32file.FILE_ATTRIBUTE_SYSTEM:
+				found[SYSTEM]+=1
+				ret[SYSTEM]=constants.HALF_CHECKED
+			#end system
+			if attrib&win32file.FILE_ATTRIBUTE_ARCHIVE:
+				found[ARCHIVE]+=1
+				ret[ARCHIVE]=constants.HALF_CHECKED
+			#end system
+		#end for
+		l=len(self)
+		if found[READONLY]==l: ret[READONLY]=constants.FULL_CHECKED
+		if found[HIDDEN]==l: ret[HIDDEN]=constants.FULL_CHECKED
+		if found[SYSTEM]==l: ret[SYSTEM]=constants.FULL_CHECKED
+		if found[ARCHIVE]==l: ret[ARCHIVE]=constants.FULL_CHECKED
+		return ret

--- a/lists/grepResult.py
+++ b/lists/grepResult.py
@@ -4,25 +4,18 @@
 #Copyright (C) 2019-2020 yamahubuki <itiro.ishino@gmail.com>
 #Note: All comments except these top lines will be written in Japanese. 
 
-import datetime
 import os
 import re
 import wx
-import win32api
-import win32file
-import constants
-import misc
-import browsableObjects
-import globalVars
-import errorCodes
-from win32com.shell import shell, shellcon
 
-from .base import *
+import browsableObjects
+import errorCodes
+import misc
+
+from .searchResultBase import *
 from .constants import *
 
-ESCAPE_PATTERN=re.compile(r"([\\\+\.\{\}\(\)\[\]\^\$\-\|\/])")
-
-class GrepResultList(FalconListBase):
+class GrepResultList(SearchResultBase):
 	"""grep検索の結果を扱うリスト。"""
 	def __init__(self):
 		super().__init__()
@@ -40,136 +33,50 @@ class GrepResultList(FalconListBase):
 		self.results=[]
 		self.lists=[self.results]
 
-	def Update(self):
-		return self.Initialize(self.rootDirectory,self.searches,self.keyword,True)
 
-	def Initialize(self,rootDirectory,searches="",keyword="",isRegularExpression=False,silent=False):
+	def Initialize(self,rootDirectory,searches=[],keyword="",isRegularExpression=False,silent=False):
 		"""与えられたファイル名のリストから、条件に一致する項目を抽出する。"""
 		if isinstance(rootDirectory,list):#パラメータがリストなら、browsableObjects のリストとして処理刷る(ファイルリストを取得しないでコピーする)
-			self.results=rootDirectory
-			self.lists=[self.results]
-			return
-		self.results.clear()
+			for elem in rootDirectory:
+				if type(elem) is browsableObjects.SearchedFolder:
+					self.folders.append(elem)
+				else:
+					self.files.append(elem)
+				#end ファイルかフォルダか
+			#end for
+			return errorCodes.OK
 		self.rootDirectory=rootDirectory
 		self.searches=searches
-		self.keyword_string=keyword
-		#ワイルドカード (アスタリスクとクエスチョン)は、正規表現に置き換えしちゃう
-		if not isRegularExpression:
-			keyword=re.sub(ESCAPE_PATTERN,r"\\\1",keyword)
-			keyword=keyword.replace("*",".*")
-			keyword=keyword.replace("?",".")
-		#end ワイルドカード置き換え
-		self.keyword=re.compile(keyword)
-		if not silent: globalVars.app.say("%sの検索結果 %s から" % (keyword,rootDirectory,))
+		self._initKeyword(keyword,isRegularExpression,silent)
 		self._initSearch()
 
-	def RedoSearch(self):
-		self._initSearch()
-
-	def _initSearch(self):
-		"""検索する前に準備する。"""
-		self.finished=False
-		self.log.debug("Getting grep search results for %s..." % self.keyword)
-		self.searched_index=0#インデックスいくつまで検索したか
-
-	def _performSearchStep(self,taskState):
-		"""検索を1ステップ実行する。100県のヒットが出るまで検索するか、リストが終わるまで検索し、終わったら関数から抜ける。途中で EOL に当たったら、検索終了としてTrueを返し、そうでないときにFalseを帰す。また、表示関数に渡しやすいように、今回のステップでヒットした要素のリストも返す。スレッドからtaskStateを受け取っていて、キャンセルされたら hits を-1にセットして抜ける。"""
-		ret_list=[]
-		i=self.searched_index
-		eol=False
-		total_hits=0
-		while(True):
-			if taskState.canceled: return False, -1#途中でキャンセル
-			path=self.searches[i]
-			if path=="eol":#EOLで検索終了
-				eol=True
-				self.finished=True
-				globalVars.app.PlaySound("complete.ogg")
-				globalVars.app.say(_("検索終了、%(item)d件ヒットしました。") % {'item': len(self)})
-				break
-			#end EOL
-			ext=path.split(".")[-1].lower()
-			if misc.isDocumentExt(ext):
-				fullpath=os.path.join(self.rootDirectory,path)
-				content=misc.ExtractText(fullpath).split("\n")
-				fileobj=None#複数ヒットでファイルオブジェクトを生成し続けないようにキャッシュする
-				ln=1
-				hitobjects=[]
-				for	 elem in content:
-					m=re.search(self.keyword,elem)
-					if m:
-						preview_start=m.start()-10
-						if preview_start<0: preview_start=0
-						preview=elem[preview_start:preview_start+20]
-						if not fileobj:
-							stat=os.stat(fullpath)
-							mod=datetime.datetime.fromtimestamp(stat.st_mtime)
-							creation=datetime.datetime.fromtimestamp(stat.st_ctime)
-							ret, shfileinfo=shell.SHGetFileInfo(fullpath,0,shellcon.SHGFI_ICON|shellcon.SHGFI_TYPENAME)
-							fileobj=browsableObjects.File()
-							fileobj.Initialize(os.path.dirname(fullpath),os.path.basename(fullpath),fullpath,stat.st_size,mod,win32file.GetFileAttributes(fullpath),shfileinfo[4],creation,win32api.GetShortPathName(fullpath))
-						#end make fileobj
-						obj=browsableObjects.GrepItem()
-						obj.Initialize(ln,preview,fileobj)
-						hitobjects.append(obj)
-					#end ヒット
-					ln+=1
-				#end 行数ごとに検索
-				if len(hitobjects)>0:#このファイルの中でヒットがあった
-					total_hits+=len(hitobjects)
-					for elem in hitobjects:
-						hits=len(hitobjects)
-						elem.SetHitCount(hits)
-					#end 最終的なヒットカウントを設定
-					self.results.extend(hitobjects)
-					ret_list.extend(hitobjects)
-				#end このファイルでヒットがあった
-			#end 対応している拡張子
-			if total_hits>=100:
-				self.searched_index=i+1#次の位置をキャッシュ
-				break
-			#end 100県検索
-			i+=1
-			if i>=len(self.searches):#検索は終わってないが、ファイルリスト取得が追いついてない
-				self.searched_index=len(self.searches)
-				break
-			#end リストが追いついてない
-		#end 検索ループ
-		return eol,ret_list
-
-	def GetKeywordString(self):
-		return self.keyword_string
-
-	def GetAttributeCheckState(self):
-		"""このリストに入っているファイルを1個ずつとって、対応するファイルの属性値を取得していく。各属性に対して、リスト内の全てのファイルが持っていれば ATTRIB_FULL_CHECKED を帰す。一部のファイルが持っていれば、 ATTRIB_HALF_CHECKED を帰す。どのファイルも持っていなければ、 ATTRIB_NOT_CHECKED を帰す。このデータを、リストにして帰す。"""
-		found=[0,0,0,0]#各属性を見つけた個数
-		ret=[constants.NOT_CHECKED, constants.NOT_CHECKED, constants.NOT_CHECKED, constants.NOT_CHECKED]#帰す値
-		for elem in self:
-			attrib=elem.attributes
-			if attrib&win32file.FILE_ATTRIBUTE_READONLY:
-				found[READONLY]+=1
-				ret[READONLY]=constants.HALF_CHECKED
-			#end readonly
-			if attrib&win32file.FILE_ATTRIBUTE_HIDDEN:
-				found[HIDDEN]+=1
-				ret[HIDDEN]=constants.HALF_CHECKED
-			#end hidden
-			if attrib&win32file.FILE_ATTRIBUTE_SYSTEM:
-				found[SYSTEM]+=1
-				ret[SYSTEM]=constants.HALF_CHECKED
-			#end system
-			if attrib&win32file.FILE_ATTRIBUTE_ARCHIVE:
-				found[ARCHIVE]+=1
-				ret[ARCHIVE]=constants.HALF_CHECKED
-			#end system
-		#end for
-		l=len(self)
-		if found[READONLY]==l: ret[READONLY]=constants.FULL_CHECKED
-		if found[HIDDEN]==l: ret[HIDDEN]=constants.FULL_CHECKED
-		if found[SYSTEM]==l: ret[SYSTEM]=constants.FULL_CHECKED
-		if found[ARCHIVE]==l: ret[ARCHIVE]=constants.FULL_CHECKED
-		return ret
-
-	def GetFinishedStatus(self):
-		return self.finished
-
+	def HitTest(self,path,ret_list):
+		"""_performSearchStepから呼ばれ、与えられたpathのファイルが検索にヒットするならリスト追加する"""
+		if misc.isDocumentExt(path.split(".")[-1]):
+			fullpath=os.path.join(self.rootDirectory,path)
+			content=misc.ExtractText(fullpath).split("\n")
+			fileobj=None#複数ヒットでファイルオブジェクトを生成し続けないようにキャッシュする
+			ln=1
+			hitobjects=[]
+			for	 elem in content:
+				m=re.search(self.keyword,elem)
+				if m:
+					preview_start=min(0,m.start()-10)
+					preview=elem[preview_start:preview_start+20]
+					if not fileobj:
+						fileobj=self._MakeObject(browsableObjects.File,fullpath)
+					obj=browsableObjects.GrepItem()
+					obj.Initialize(ln,preview,fileobj)
+					hitobjects.append(obj)
+				#end ヒット
+				ln+=1
+			#end 行数ごとに検索
+			for elem in hitobjects:
+				hits=len(hitobjects)
+				elem.SetHitCount(hits)
+			#end 最終的なヒットカウントを設定
+			self.results.extend(hitobjects)
+			ret_list.extend(hitobjects)
+			return len(hitobjects)
+		#end 対応している拡張子
+		return 0

--- a/lists/searchResult.py
+++ b/lists/searchResult.py
@@ -4,25 +4,17 @@
 #Copyright (C) 2019-2020 yamahubuki <itiro.ishino@gmail.com>
 #Note: All comments except these top lines will be written in Japanese. 
 
-import datetime
 import os
 import re
 import wx
-import win32api
-import win32file
-import constants
-import misc
 import browsableObjects
 import globalVars
 import errorCodes
-from win32com.shell import shell, shellcon
 
-from .base import *
+from .searchResultBase import *
 from .constants import *
 
-ESCAPE_PATTERN=re.compile(r"([\\\+\.\{\}\(\)\[\]\^\$\-\|\/])")
-
-class SearchResultList(FalconListBase):
+class SearchResultList(SearchResultBase):
 	"""ファイルとフォルダの一覧を扱うリスト。"""
 	def __init__(self):
 		super().__init__()
@@ -39,10 +31,7 @@ class SearchResultList(FalconListBase):
 		self.files=[]
 		self.lists=[self.folders,self.files]
 
-	def Update(self):
-		return self.Initialize(self.rootDirectory,self.searches,self.keyword,True)
-
-	def Initialize(self,rootDirectory,searches="",keyword="",isRegularExpression=False,silent=False):
+	def Initialize(self,rootDirectory,searches=[],keyword="",isRegularExpression=False,silent=False):
 		"""与えられたファイル名のリストから、条件に一致する項目を抽出する。"""
 		if isinstance(rootDirectory,list):#パラメータがリストなら、browsableObjects のリストとして処理刷る(ファイルリストを取得しないでコピーする)
 			for elem in rootDirectory:
@@ -53,115 +42,25 @@ class SearchResultList(FalconListBase):
 				#end ファイルかフォルダか
 			#end for
 			return errorCodes.OK
-		self.folders.clear()
-		self.files.clear()
 		self.rootDirectory=rootDirectory
 		self.searches=searches
-		self.keyword_string=keyword
-		#ワイルドカード (アスタリスクとクエスチョン)は、正規表現に置き換えしちゃう
-		if not isRegularExpression:
-			keyword=re.sub(ESCAPE_PATTERN,r"\\\1",keyword)
-			keyword=keyword.replace("*",".*")
-			keyword=keyword.replace("?",".")
-		#end ワイルドカード置き換え
-		self.keyword=re.compile(keyword)
-		if not silent: globalVars.app.say("%sの検索結果 %s から" % (keyword,rootDirectory,))
+		self._initKeyword(keyword,isRegularExpression,silent)
 		self._initSearch()
 
-	def RedoSearch(self):
-		self._initSearch()
-
-	def _initSearch(self):
-		"""検索する前に準備する。"""
-		self.finished=False
-		self.folders=[]
-		self.files=[]
-		self.lists=[self.folders,self.files]
-		self.log.debug("Getting search results for %s..." % self.keyword)
-		self.searched_index=0#インデックスいくつまで検索したか
-
-	def _performSearchStep(self,taskState):
-		"""検索を1ステップ実行する。100県のファイルがヒットするか、リストが終わるまで検索し、終わったら関数から抜ける。途中で EOL に当たったら、検索終了としてTrueを返し、そうでないときにFalseを帰す。また、表示関数に渡しやすいように、今回のステップでヒットした要素のリストも返す。"""
-		ret_list=[]
-		i=self.searched_index
-		eol=False
-		hit=0
-		while(True):
-			if taskState.canceled: return False, -1#途中でキャンセル
-			path=self.searches[i]
-			if path=="eol":#EOLで検索終了
-				eol=True
-				self.finished=True
-				globalVars.app.PlaySound("complete.ogg")
-				globalVars.app.say(_("検索終了、%(item)d件ヒットしました。") % {'item': len(self)})
-				break
-			#end EOL
-			if re.search(self.keyword,path):
-				fullpath=os.path.join(self.rootDirectory,path)
-				stat=os.stat(fullpath)
-				mod=datetime.datetime.fromtimestamp(stat.st_mtime)
-				creation=datetime.datetime.fromtimestamp(stat.st_ctime)
-				ret, shfileinfo=shell.SHGetFileInfo(fullpath,0,shellcon.SHGFI_ICON|shellcon.SHGFI_TYPENAME)
-				if os.path.isfile(fullpath):
-					f=browsableObjects.SearchedFile()
-					f.Initialize(os.path.dirname(fullpath),os.path.basename(fullpath),fullpath,stat.st_size,mod,win32file.GetFileAttributes(fullpath),shfileinfo[4],creation,win32api.GetShortPathName(fullpath))
-					self.files.append(f)
-					ret_list.append(f)
-				else:
-					f=browsableObjects.SearchedFolder()
-					f.Initialize(os.path.dirname(fullpath),os.path.basename(fullpath),fullpath,-1,mod,win32file.GetFileAttributes(fullpath),shfileinfo[4],creation,win32api.GetShortPathName(fullpath))
-					self.folders.append(f)
-					ret_list.append(f)
-				#end ファイルかフォルダか
-				hit+=1
-				if hit==100:
-					self.searched_index=i+1#次の位置をキャッシュ
-					break
-				#end 100県ヒット
-			#end 検索ヒットか
-			i+=1
-			if i>=len(self.searches):#検索は終わってないが、ファイルリスト取得が追いついてない
-				self.searched_index=len(self.searches)
-				break
-			#end リストが追いついてない
-		#end 検索ループ
-		return eol,ret_list
-
-	def GetKeywordString(self):
-		return self.keyword_string
-
-	def GetAttributeCheckState(self):
-		"""このリストに入っているファイルを1個ずつとって、対応するファイルの属性値を取得していく。各属性に対して、リスト内の全てのファイルが持っていれば ATTRIB_FULL_CHECKED を帰す。一部のファイルが持っていれば、 ATTRIB_HALF_CHECKED を帰す。どのファイルも持っていなければ、 ATTRIB_NOT_CHECKED を帰す。このデータを、リストにして帰す。"""
-		found=[0,0,0,0]#各属性を見つけた個数
-		ret=[constants.NOT_CHECKED, constants.NOT_CHECKED, constants.NOT_CHECKED, constants.NOT_CHECKED]#帰す値
-		for elem in self:
-			attrib=elem.attributes
-			if attrib&win32file.FILE_ATTRIBUTE_READONLY:
-				found[READONLY]+=1
-				ret[READONLY]=constants.HALF_CHECKED
-			#end readonly
-			if attrib&win32file.FILE_ATTRIBUTE_HIDDEN:
-				found[HIDDEN]+=1
-				ret[HIDDEN]=constants.HALF_CHECKED
-			#end hidden
-			if attrib&win32file.FILE_ATTRIBUTE_SYSTEM:
-				found[SYSTEM]+=1
-				ret[SYSTEM]=constants.HALF_CHECKED
-			#end system
-			if attrib&win32file.FILE_ATTRIBUTE_ARCHIVE:
-				found[ARCHIVE]+=1
-				ret[ARCHIVE]=constants.HALF_CHECKED
-			#end system
-		#end for
-		l=len(self)
-		if found[READONLY]==l: ret[READONLY]=constants.FULL_CHECKED
-		if found[HIDDEN]==l: ret[HIDDEN]=constants.FULL_CHECKED
-		if found[SYSTEM]==l: ret[SYSTEM]=constants.FULL_CHECKED
-		if found[ARCHIVE]==l: ret[ARCHIVE]=constants.FULL_CHECKED
-		return ret
-
-	def GetFinishedStatus(self):
-		return self.finished
+	def HitTest(self,path,ret_list):
+		"""_performSearchStepから呼ばれ、与えられたpathのファイルが検索にヒットするならリスト追加する"""
+		if re.search(self.keyword,path):
+			fullpath=os.path.join(self.rootDirectory,path)
+			if os.path.isfile(fullpath):
+				f=self._MakeObject(browsableObjects.SearchedFile,fullpath)
+				self.files.append(f)
+			else:
+				f=self._MakeObject(browsableObjects.SearchedFolder,fullpath,True)
+				self.folders.append(f)
+			#end ファイルかフォルダか
+			ret_list.append(f)
+			return 1
+		return 0
 
 	def GetFolderFileNumber(self):
 		return len(self.folders), len(self.files)

--- a/lists/searchResultBase.py
+++ b/lists/searchResultBase.py
@@ -1,0 +1,109 @@
+﻿# -*- coding: utf-8 -*-
+#Falcon searchResultBase Function
+#Copyright (C) 2019-2020 Yukio Nozawa <personal@nyanchangames.com>
+#Copyright (C) 2019-2020 yamahubuki <itiro.ishino@gmail.com>
+#Note: All comments except these top lines will be written in Japanese. 
+
+import datetime
+import os
+import re
+import wx
+import win32api
+import win32file
+import constants
+import globalVars
+
+from win32com.shell import shell, shellcon
+
+from .fileListBase import *
+
+ESCAPE_PATTERN=re.compile(r"([\\\+\.\{\}\(\)\[\]\^\$\-\|\/])")
+
+class SearchResultBase(FileListBase):
+	def __init__(self):
+		super().__init__()
+
+	def _performSearchStep(self,taskState):
+		"""検索を1ステップ実行する。100県のファイルがヒットするか、リストが終わるまで検索し、終わったら関数から抜ける。途中で EOL に当たったら、検索終了としてTrueを返し、そうでないときにFalseを帰す。また、表示関数に渡しやすいように、今回のステップでヒットした要素のリストも返す。"""
+		ret_list=[]
+		i=self.searched_index
+		hit=0
+		while(True):
+			if taskState.canceled: return False, -1#途中でキャンセル
+			path=self.searches[i]
+			if path=="eol":#EOLで検索終了
+				self.finished=True
+				globalVars.app.PlaySound("complete.ogg")
+				globalVars.app.say(_("検索終了、%(item)d件ヒットしました。") % {'item': len(self)})
+				return True,ret_list
+			#end EOL
+			result=self.HitTest(path,ret_list)
+			hit+=result
+			if hit==100:
+				self.searched_index=i+1#次の位置をキャッシュ
+				break
+			#end 100県ヒット
+			i+=1
+			if i>=len(self.searches):#検索は終わってないが、ファイルリスト取得が追いついてない
+				self.searched_index=len(self.searches)
+				break
+			#end リストが追いついてない
+		#end 検索ループ
+		return False,ret_list
+
+	def GetFinishedStatus(self):
+		"""
+			workerThreadTaskでの検索処理が終わっているならTrue
+			画面上のlistCtrlへの追加完了とは一致しない
+		"""
+		return self.finished
+
+	def GetKeywordString(self):
+		return self.keyword_string
+
+	def _initKeyword(self,keyword,isRegularExpression,silent):
+		self.keyword_string=keyword
+		#ワイルドカード (アスタリスクとクエスチョン)は、正規表現に置き換えしちゃう
+		if not isRegularExpression:
+			keyword=re.sub(ESCAPE_PATTERN,r"\\\1",keyword)
+			keyword=keyword.replace("*",".*")
+			keyword=keyword.replace("?",".")
+		#end ワイルドカード置き換え
+		self.keyword=re.compile(keyword)
+		if not silent: globalVars.app.say("%sの検索結果 %s から" % (keyword,self.rootDirectory,))
+
+	def _initSearch(self):
+		"""検索する前に準備する。"""
+		self.finished=False
+		for l in self.lists:
+			l.clear()
+		self.log.debug("Getting search results for %s..." % self.keyword)
+		self.searched_index=0#インデックスいくつまで検索したか
+
+	def _MakeObject(self,objType,fullpath,isDir=False):
+		stat=os.stat(fullpath)
+		ret, shfileinfo=shell.SHGetFileInfo(fullpath,0,shellcon.SHGFI_ICON | shellcon.SHGFI_TYPENAME)
+		obj=objType()
+		if isDir:
+			size=-1
+		else:
+			size=stat.st_size
+		obj.Initialize(
+			os.path.dirname(fullpath),						#directory
+			os.path.basename(fullpath),						#basename
+			fullpath,
+			size,									#size
+			datetime.datetime.fromtimestamp(stat.st_mtime),	#modDate
+			win32file.GetFileAttributes(fullpath),			#attributes
+			shfileinfo[4],									#typeString
+			datetime.datetime.fromtimestamp(stat.st_ctime),	#creationDate
+			win32api.GetShortPathName(fullpath),			#shortName
+			shfileinfo[0]									#hIcon
+		)
+		return obj
+
+	def Update(self):
+		return self.Initialize(self.rootDirectory,self.searches,self.keyword,True)
+
+	def RedoSearch(self):
+		self._initSearch()

--- a/misc.py
+++ b/misc.py
@@ -258,5 +258,5 @@ def CommandLineToArgv(cmd):
 
 #渡された拡張子がドキュメント形式であればTrue
 def isDocumentExt(ext):
-	return ext in constants.SUPPORTED_DOCUMENT_FORMATS | globalVars.app.documentFormats
+	return ext.lower() in constants.SUPPORTED_DOCUMENT_FORMATS | globalVars.app.documentFormats
 

--- a/tabs/base.py
+++ b/tabs/base.py
@@ -497,7 +497,7 @@ class FalconTabBase(object):
 	def SortCycleAd(self):
 		"""昇順と降順を交互に切り替える。"""
 		self.listObject.SetSortDescending(self.listObject.GetSortDescending()==0)
-		self.ApplySort
+		self.ApplySort()
 
 	def SortSelect(self):
 		"""並び順を指定する。"""
@@ -544,7 +544,6 @@ class FalconTabBase(object):
 	def SortNext(self):
 		self.listObject.SetSortCursor()
 		self.ApplySort()
-	#end sortNext
 
 	def ApplySort(self):
 		self._updateConfig()				#設定の保存

--- a/tabs/base.py
+++ b/tabs/base.py
@@ -292,13 +292,13 @@ class FalconTabBase(object):
 
 	def Update(self,lst,cursor=-1):
 		"""指定された要素をタブに適用する。"""
-		self._cancelBackgroundTasks()
-		self.hListCtrl.DeleteAllItems()
+		self.DeleteAllItems()		#先に消しておかないとカラム数が合わない画面がユーザに見えてしまう
 		if type(lst)!=type(self.listObject):
 			self.SetListColumns(lst)
 		self.listObject=lst
 		self.environment["listType"]=type(lst)
 		self.UpdateListContent(self.listObject.GetItemList())
+
 		self.Focus(cursor)
 
 		#タブの名前変更を通知
@@ -310,14 +310,7 @@ class FalconTabBase(object):
 			カラムの数やテキストは変更しない。
 		"""
 		self.log.debug("Updating list control...")
-		self._cancelBackgroundTasks()
-		self.hListCtrl.DeleteAllItems()
-		self.ItemSelected()			#メニューバーのアイテムの状態更新処理。選択中アイテムがいったん0になってる場合があるため必要。
-		self.checkedItem=set()
-		globalVars.app.hMainView.menu.Enable(menuItemsStore.getRef("EDIT_UNMARKITEM_ALL"),False)
-		self.hilightIndex=-1
-
-		self._InitIconList()
+		self.DeleteAllItems()
 
 		t=misc.Timer()
 		for elem in content:
@@ -672,6 +665,18 @@ class FalconTabBase(object):
 
 	def hasCheckedItem(self):
 		return len(self.checkedItem)>0
+
+	def DeleteAllItems(self):
+		"""
+			必用な調整を経て、リストビューを空にする
+			別途listObjectについては処理が必要
+		"""
+		self._cancelBackgroundTasks()
+		self.hListCtrl.DeleteAllItems()
+		self.ItemSelected()			#メニューバーのアイテムの状態更新処理。選択中アイテムがいったん0になってるため必要		self.checkedItem=set()
+		globalVars.app.hMainView.menu.Enable(menuItemsStore.getRef("EDIT_UNMARKITEM_ALL"),False)
+		self.hilightIndex=-1
+		self._InitIconList()
 
 	def ItemFocused(self,event):
 		#チェック機能仕様中の複数選択は不可

--- a/tabs/base.py
+++ b/tabs/base.py
@@ -350,6 +350,8 @@ class FalconTabBase(object):
 
 	def _InitIconList(self):
 		"""listCtrlにアイコン設定する準備"""
+		if self.listObject==None:
+			return
 		self.hIconList=wx.ImageList(32,32,False,len(self.listObject))
 		self.hListCtrl.AssignImageList(self.hIconList,wx.IMAGE_LIST_SMALL)
 		self.iconNumbers={}

--- a/tabs/fileList.py
+++ b/tabs/fileList.py
@@ -215,7 +215,6 @@ class FileListTab(base.FalconTabBase):
 		c.SendToClipboard()
 
 	def GoToTopFile(self):
-		#end ファイルリストのときしか通さない
 		self.Focus(self.listObject.GetTopFileIndex())
 		globalVars.app.say(_("先頭ファイル"))
 

--- a/tabs/searchResultTabBase.py
+++ b/tabs/searchResultTabBase.py
@@ -49,9 +49,7 @@ class SearchResultTabBase(tabs.fileList.FileListTab):
 			self.hListCtrl.Append(elem.GetListTuple())
 		#end 追加
 		if self.listObject.GetFinishedStatus():
-			self.listObject.ApplySort()
-			self.hListCtrl.DeleteAllItems()
-			self.UpdateListContent(self.listObject.GetItems())
+			self.ApplySort()
 
 	def UpdateFilelist(self,silence=False,cursorTargetName=""):
 		"""検索をやり直す。ファイルは非同期処理で増えるので、cursorTargetNameは使用されない。"""

--- a/tabs/searchResultTabBase.py
+++ b/tabs/searchResultTabBase.py
@@ -62,7 +62,6 @@ class SearchResultTabBase(tabs.fileList.FileListTab):
 		#end 追加
 		if self.tempListObject.GetFinishedStatus() and self.hListCtrl.GetItemCount()==len(self.tempListObject):
 			#ここはcallAfterで実行されるため、検索修了時点でCallAfterのキューに２つ以上のこの関数が貯まってるとソートが２回発生して画面とリストがずれるので条件を二重にして対策した
-			print("sort")
 			self.ApplySort()
 
 

--- a/tabs/searchResultTabBase.py
+++ b/tabs/searchResultTabBase.py
@@ -18,6 +18,9 @@ import workerThreads
 import workerThreadTasks
 
 class SearchResultTabBase(tabs.fileList.FileListTab):
+	def __init__(self,environment):
+		super().__init__(environment)
+		self.folderCount=0
 
 	blockMenuList=[
 		"FILE_MKDIR",
@@ -36,8 +39,11 @@ class SearchResultTabBase(tabs.fileList.FileListTab):
 	def StartSearch(self,rootPath,searches,keyword, isRegularExpression):
 		self.listObject=self.listType()
 		self.listObject.Initialize(rootPath,searches,keyword, isRegularExpression)
+		self.tempListObject=self.listType()
+		self.tempListObject.Initialize(rootPath,searches,keyword, isRegularExpression)
 		self.SetListColumns(self.listObject)
-		workerThreads.RegisterTask(workerThreadTasks.PerformSearch,{'listObject': self.listObject, 'tabObject': self})
+		self._InitIconList()
+		workerThreads.RegisterTask(workerThreadTasks.PerformSearch,{'listObject': self.tempListObject, 'tabObject': self})
 
 		#タブの名前変更を通知
 		globalVars.app.hMainView.UpdateTabName()
@@ -46,14 +52,23 @@ class SearchResultTabBase(tabs.fileList.FileListTab):
 		"""コールバックで、ヒットしたオブジェクトのリストが降ってくるので、それをリストビューに追加していく。"""
 		globalVars.app.PlaySound("click.ogg")
 		for elem in hits:
-			self.hListCtrl.Append(elem.GetListTuple())
+			if isinstance(elem,browsableObjects.Folder):
+				self._AppendElement(elem,self.folderCount)
+				self.folderCount+=1
+				self.listObject.folders.append(elem)
+			else:
+				self._AppendElement(elem)
+				self.listObject.lists[-1].append(elem)
 		#end 追加
-		if self.listObject.GetFinishedStatus():
+		if self.tempListObject.GetFinishedStatus() and self.hListCtrl.GetItemCount()==len(self.tempListObject):
+			#ここはcallAfterで実行されるため、検索修了時点でCallAfterのキューに２つ以上のこの関数が貯まってるとソートが２回発生して画面とリストがずれるので条件を二重にして対策した
+			print("sort")
 			self.ApplySort()
+
 
 	def UpdateFilelist(self,silence=False,cursorTargetName=""):
 		"""検索をやり直す。ファイルは非同期処理で増えるので、cursorTargetNameは使用されない。"""
-		if not self.listObject.GetFinishedStatus():
+		if not self.tempListObject.GetFinishedStatus():
 			globalVars.app.say(_("現在検索中です。再建策はできません。"), interrupt=True)
 			return
 		#end まだ検索終わってない
@@ -61,6 +76,8 @@ class SearchResultTabBase(tabs.fileList.FileListTab):
 			globalVars.app.say(_("再建策"), interrupt=True)
 		#end not silence
 		self.hListCtrl.DeleteAllItems()
+		self.folderCount=0
+		self._InitIconList()
 		self.listObject.RedoSearch()
 		workerThreads.RegisterTask(workerThreadTasks.PerformSearch,{'listObject': self.listObject, 'tabObject': self})
 
@@ -81,7 +98,7 @@ class SearchResultTabBase(tabs.fileList.FileListTab):
 		return errorCodes.BOUNDARY
 
 	def ReadCurrentFolder(self):
-		state=_("検索完了") if self.listObject.GetFinishedStatus() is True else _("検索中")
+		state=_("検索完了") if self.tempListObject.GetFinishedStatus() is True else _("検索中")
 		globalVars.app.say(_("キーワード %(keyword)s で ディレクトリ %(dir)s を%(state)s") % {'keyword': self.listObject.GetKeywordString(), 'dir': self.listObject.rootDirectory, 'state': state}, interrupt=True)
 
 	def ReadListItemNumber(self,short=False):

--- a/tabs/searchResultTabBase.py
+++ b/tabs/searchResultTabBase.py
@@ -75,9 +75,7 @@ class SearchResultTabBase(tabs.fileList.FileListTab):
 		if silence==False:
 			globalVars.app.say(_("再建策"), interrupt=True)
 		#end not silence
-		self.hListCtrl.DeleteAllItems()
-		self.folderCount=0
-		self._InitIconList()
+		self.DeleteAllItems()
 		self.listObject.RedoSearch()
 		workerThreads.RegisterTask(workerThreadTasks.PerformSearch,{'listObject': self.listObject, 'tabObject': self})
 
@@ -110,3 +108,7 @@ class SearchResultTabBase(tabs.fileList.FileListTab):
 		word=StringUtil.GetLimitedString(word,globalVars.app.config["view"]["header_title_length"])
 		word=_("%(word)sの検索") % {"word":word}
 		return word
+
+	def DeleteAllItems(self):
+		super().DeleteAllItems()
+		self.folderCount=0

--- a/views/main.py
+++ b/views/main.py
@@ -550,7 +550,7 @@ class Events(BaseEvents):
 			self.parent.activeTab.Delete()
 			return
 		if selected==menuItemsStore.getRef("FILE_VIEW_DETAIL"):
-			elem=self.parent.activeTab.listObject.GetElement(self.parent.activeTab.GetFocusedItem())
+			elem=self.parent.activeTab.GetFocusedElement()
 			self.ShowDetail(elem)
 			return
 		if selected==menuItemsStore.getRef("FILE_SHOWPROPERTIES"):
@@ -837,10 +837,7 @@ class Events(BaseEvents):
 		dic={}
 		dic[_("名前")]=elem.basename
 		dic[_("パス")]=elem.fullpath
-		if elem.__class__==browsableObjects.File or elem.__class__==browsableObjects.Stream:
-			dic[_("サイズ")]=misc.ConvertBytesTo(elem.size,misc.UNIT_AUTO,True)
-			dic[_("サイズ(バイト)")]=elem.size
-		elif elem.__class__==browsableObjects.Folder:
+		if isinstance(elem,browsableObjects.Folder):
 			if elem.size>=0:
 				dic[_("サイズ")]=misc.ConvertBytesTo(elem.size,misc.UNIT_AUTO,True)
 				dic[_("サイズ(バイト)")]=elem.size
@@ -852,6 +849,9 @@ class Events(BaseEvents):
 				else:
 					dic[_("サイズ")]=_("不明")
 					dic[_("サイズ(バイト)")]=_("不明")
+		elif isinstance(elem,browsableObjects.File) or elem.__class__==browsableObjects.Stream:
+			dic[_("サイズ")]=misc.ConvertBytesTo(elem.size,misc.UNIT_AUTO,True)
+			dic[_("サイズ(バイト)")]=elem.size
 		if isinstance(elem,browsableObjects.File):
 			dic[_("作成日時")]=elem.creationDate.strftime("%Y/%m/%d(%a) %H:%M:%S")
 			dic[_("更新日時")]=elem.modDate.strftime("%Y/%m/%d(%a) %H:%M:%S")

--- a/views/main.py
+++ b/views/main.py
@@ -591,9 +591,6 @@ class Events(BaseEvents):
 			return
 		if selected==menuItemsStore.getRef("TOOL_ADDPATH"):
 			t=self.parent.activeTab.GetSelectedItems()
-			if item in t:
-				if item.__class__!=browsableObjects.Folder:
-					return
 			t=t.GetItemPaths()
 			if misc.addPath(t):
 				dialog(_("パスの追加"),_("ユーザ環境変数PATHに追加しました。"))
@@ -849,7 +846,7 @@ class Events(BaseEvents):
 				else:
 					dic[_("サイズ")]=_("不明")
 					dic[_("サイズ(バイト)")]=_("不明")
-		elif isinstance(elem,browsableObjects.File) or elem.__class__==browsableObjects.Stream:
+		elif isinstance(elem,browsableObjects.File) or type(elem)==browsableObjects.Stream:
 			dic[_("サイズ")]=misc.ConvertBytesTo(elem.size,misc.UNIT_AUTO,True)
 			dic[_("サイズ(バイト)")]=elem.size
 		if isinstance(elem,browsableObjects.File):
@@ -861,7 +858,7 @@ class Events(BaseEvents):
 				dic[_("短い名前")]=elem.shortName
 			else:
 				dic[_("短い名前")]=_("なし")
-		if elem.__class__==browsableObjects.Drive:
+		if type(elem)==browsableObjects.Drive:
 			if elem.free>=0:
 				dic[_("フォーマット")]=fileSystemManager.GetFileSystemObject(elem.letter)
 				dic[_("空き容量")]=misc.ConvertBytesTo(elem.free, misc.UNIT_AUTO,True)
@@ -872,7 +869,7 @@ class Events(BaseEvents):
 			if elem.free>=0:
 				dic[_("総容量")]=misc.ConvertBytesTo(elem.total, misc.UNIT_AUTO, True)
 			dic[_("種類")]=elem.typeString
-		if elem.__class__==browsableObjects.NetworkResource:
+		if type(elem)==browsableObjects.NetworkResource:
 			dic[_("IPアドレス")]=elem.address
 		d=views.objectDetail.Dialog()
 		d.Initialize(dic)


### PR DESCRIPTION
検索結果の扱いに対して大幅なアルゴリズム変更とコードの整理をしています。
検索で見つかった項目はファイル・フォルダにわけて格納しないと他との互換が取れないのでそういう仕様に買えました。

今後、インデックスを使ってやっている各種処理を、順次browsableObjectsでの受け渡しに置き換えます。処理終了後はbrowsableObjectsを基にインデックスを探し、そこを書き換えるという流れにすれば、検索中に何をされても大丈夫になる予定です。

差分の量が増えすぎるとやばいので、一旦確認の上マージ願います。

なお、もし今後検索関連をいじるとき、ついでにsearchResultTabBase.tempListObjectはわざわざListObjectじゃなくてよいんだよなあ。だからそこの関係でlistObjectが持ってる検索関連関数も分離できるなあというところを直してくれると嬉しいです。