### PR TITLE
IteratePathsで失敗したパスをスキップ+ドライブ直下から検索すると全部失敗するのを修正

### DIFF
--- a/misc.py
+++ b/misc.py
@@ -156,12 +156,17 @@ def disableWindowStyleFlag(hwnd,flag):
 
 def IteratePaths(path,append_eol=False):
 	"""FindFirstFile 系を使って、パス名をイテレートする。append_eol=True にすると、最後に "eol" という1行をリストに入れるので、検索の終了判定などに使える。"""
-	for elem in win32file.FindFilesIterator(path+"\\*"):
-		if elem[8]=="." or elem[8]=="..": continue
-		if elem[0]&win32file.FILE_ATTRIBUTE_DIRECTORY: 
-			yield from IteratePaths(os.path.join(path,elem[8]))
-		#end ディレクトリ
-		yield os.path.join(path,elem[8])
+	try:
+		for elem in win32file.FindFilesIterator(path+"\\*"):
+			if elem[8]=="." or elem[8]=="..": continue
+			if elem[0]&win32file.FILE_ATTRIBUTE_DIRECTORY: 
+				yield from IteratePaths(path+"\\"+elem[8])
+			#end ディレクトリ
+			yield os.path.join(path,elem[8])
+		#end iterate
+	except pywintypes.error as e:
+		log.error("Access denied while searching paths at %s (%s)." % (path,e))
+	#end except
 	#EOL挿入
 	if append_eol: yield "eol"
 


### PR DESCRIPTION
まさか、
os.path.join("C:","test") が C:\test ではなく C:test になってしまうとは。だめよのう。