### PR TITLE
falconHelperをビルドするときに出るいくつかの渓谷に対処

### DIFF
--- a/falconHelper/disctype.cpp
+++ b/falconHelper/disctype.cpp
@@ -273,7 +273,7 @@ falcon_helper_funcdef char *getDiscDriveTypes()
         }
         tmp = (VARIANT *)(profiles->pvData);
         std::vector<int> profile_values;
-        for (int i = 0; i < profiles->rgsabound[0].cElements; i++)
+        for (unsigned int i = 0; i < profiles->rgsabound[0].cElements; i++)
         {
             //????R?????g?A?E?g??????A?T?|?[?g???????v???t?@?C????????o??
             //std::cout << "    profile " << tmp[i].lVal << std::endl;

--- a/falconHelper/findradiobuttons.cpp
+++ b/falconHelper/findradiobuttons.cpp
@@ -37,7 +37,7 @@ falcon_helper_funcdef char *findRadioButtons(HWND wnd)
     wnds.clear();
     EnumChildWindows(wnd, EnumChildProc, 0);
     string s;
-    for (int i = 0; i < wnds.size(); ++i)
+    for (unsigned int i = 0; i < wnds.size(); ++i)
     {
         s += wnds[i];
         if (i != wnds.size() - 1)

--- a/falconHelper/makefile
+++ b/falconHelper/makefile
@@ -1,4 +1,4 @@
-CPPFLAGS= /nologo /W3 /c /EHsc /O2
+CPPFLAGS= /nologo /W3 /c /EHsc /O2 /wd4819
 OBJS= common.obj contextmenu.obj ctlcolor.obj disctype.obj findradiobuttons.obj ejectDevice.obj extracttext.obj helper_funcs.obj
 LIBS= user32.lib Ole32.lib OleAut32.lib gdi32.lib Cfgmgr32.lib Setupapi.lib shell32.lib
 .SILENT:


### PR DESCRIPTION
- unsigned int と int の比較を直す
- Warning C4819は、ファイルを UTF-16LE で保存すると消えるが、そうするとgit管理が面倒になるので、 makefile でコンパイラオプションを付けて消す
- warning C4996はまだ