### PR TITLE
Bump appveyor python version to 3.8

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
     # The list here is complete (excluding Python 2.6, which
     # isn't covered by this document) at the time of writing.
 
-    - PYTHON: "C:\\Python37"
+    - PYTHON: "C:\\Python38"
 
 install:
   # We need wheel installed to build wheels


### PR DESCRIPTION
手元で python3.8 + pyinstaller のビルドが通って実行もできたので、 appveyor のほうも上げます。