### PR TITLE
貼り付け後タブを閉じると自動的に更新されるようにした(暫定処理で検討の余地はある)

### DIFF
--- a/tabs/base.py
+++ b/tabs/base.py
@@ -330,7 +330,9 @@ class FalconTabBase(object):
         self.DeleteAllItems()  # 先に消しておかないとカラム数が合わない画面がユーザに見えてしまう
         if not isinstance(lst, type(self.listObject)):
             self.SetListColumns(lst)
-        if hasattr(lst, "rootDirectory") and self.environment["history"].isEmpty():  # タブ作成時のみ
+        if hasattr(
+                lst,
+                "rootDirectory") and self.environment["history"].isEmpty():  # タブ作成時のみ
             self.environment["history"].add(lst.rootDirectory)
         self.listObject = lst
         self.environment["listType"] = type(lst)
@@ -768,7 +770,7 @@ class FalconTabBase(object):
         """選択中のフォルダやドライブに入るか、選択中のファイルを実行する。stream=True の場合、ファイルの NTFS 副ストリームを開く。"""
         index = self.GetFocusedItem()
         elem = self.listObject.GetElement(index)
-        if not stream and type(elem)==browsableObjects.File:  # このファイルを開く
+        if not stream and isinstance(elem, browsableObjects.File):  # このファイルを開く
             print("open")
             misc.RunFile(
                 elem.fullpath,
@@ -1123,6 +1125,10 @@ class FalconTabBase(object):
 
     def OnClose(self):
         """タブが閉じられる前に呼び出される。検索結果タブでは、検索中にタブが閉じられたとき、検索のための非同期処理のキャンセルを待機しなければならない。"""
+        pass
+
+    def onReactivate(self):
+        """別のタブからこのタブにフォーカスが移動し、アクティブ状態となった際に呼ばれる。今のところ、ctrl+wでタブを閉じたとき、閉じてアクティブになったタブに対してのみ呼ばれる。"""
         pass
 
     def _LostFocus(self, event=None):

--- a/tabs/fileList.py
+++ b/tabs/fileList.py
@@ -420,3 +420,6 @@ class FileListTab(base.FalconTabBase):
     def GetRootObject(self):
         """ドライブ詳細情報表示で用いる"""
         return misc.GetRootObject(self.listObject.rootDirectory)
+
+    def onReactivate(self):
+        self.UpdateFilelist(silence=True)

--- a/views/main.py
+++ b/views/main.py
@@ -197,12 +197,14 @@ class View(BaseView):
         self.UpdateTabName()
     # end ReplaceCurrentTab
 
-    def ActivateTab(self, pageNo):
+    def ActivateTab(self, pageNo, triggerOnReactivate=False):
         """指定されたインデックスのタブをアクティブにする。"""
         self.UpdateMenuState(self.activeTab, self.tabs[pageNo])
         self.activeTab = self.tabs[pageNo]
         self.hTabCtrl.SetSelection(pageNo)
         self.menu.ApplyShortcut(self.activeTab.hListCtrl)
+        if triggerOnReactivate:
+            self.activeTab.onReactivate()
 
     def CloseTab(self, pageNo):
         """指定されたインデックスのタブを閉じる。閉じたタブがアクティブだった場合は、別のタブをアクティブ状態にする。全てのタブが閉じられた場合は、終了イベントを投げる。"""
@@ -219,6 +221,7 @@ class View(BaseView):
             pageNo = found
         # end ページ番号じゃなかったときの検索
 
+        active_tab = self.activeTab
         popped_tab = self.tabs.pop(pageNo)
         popped_tab.OnClose()
         if len(self.tabs) == 0:  # タブがなくなった
@@ -228,11 +231,13 @@ class View(BaseView):
         # この時点で、 noteBook がリストコントロールをデリートするらしいので、他の場所で明示的に消してはいけないとリファレンスに書いてある
         self.hTabCtrl.DeletePage(pageNo)
         self.hTabCtrl.SendSizeEvent()
-        if self.activeTab is popped_tab:  # アクティブなタブを閉じた
+        if active_tab is popped_tab:  # アクティブなタブを閉じた
+            print("popped tab")
             new_pageNo = pageNo
             if new_pageNo >= len(self.tabs):
                 new_pageNo = len(self.tabs) - 1
-            self.ActivateTab(new_pageNo)
+            print("trigger")
+            self.ActivateTab(new_pageNo, triggerOnReactivate=True)
         # end アクティブタブを閉じた場合に後ろのタブを持って来る
     # end closeTab
 


### PR DESCRIPTION
本当は、shift+tabでタブを変更したときにもonReactivateを書けて、常に最新の状態が見られるようにしたかったのだが、新規タブ精製時にもwxのChangeTabが発火してしまい、新しくできたタブなのか、タブを普通に変えただけなのか区別できなかった。