### PR TITLE
スレッド内で例外が起きたときの処理を改善

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,8 @@
 import os
 import proxyUtil
 import wx
+import threading
+import sys
 
 import AppBase
 import constants
@@ -59,6 +61,22 @@ class falconAppMain(AppBase.MaiｎBase):
             "Finished mainView setup (%f seconds from start)" %
             t.elapsed)
         return True
+
+    def installThreadExcepthook(self):
+        _init = threading.Thread.__init__
+
+        def init(self, *args, **kwargs):
+            _init(self, *args, **kwargs)
+            _run = self.run
+
+            def run(*args, **kwargs):
+                try:
+                    _run(*args, **kwargs)
+                except:
+                    sys.excepthook(*sys.exc_info())
+            self.run = run
+
+        threading.Thread.__init__ = init
 
     def LoadUserCommandSettings(self):
         """お気に入りフォルダと「ここで開く」の設定を読み込む"""

--- a/app.py
+++ b/app.py
@@ -31,6 +31,8 @@ class falconAppMain(AppBase.MaiｎBase):
         # プロキシの設定を適用
         self.proxyEnviron = proxyUtil.virtualProxyEnviron()
         self.setProxyEnviron()
+        # スレッドで例外が起きてもsys.exceptHookが呼ばれるようにする
+        self.installThreadExcepthook()
         # アップデートを実行
         if self.config.getboolean("general", "update"):
             globalVars.update.update(True)


### PR DESCRIPTION
バグなのか仕様なのか不明ですが、メインスレッド以外で例外が起きたとき、```sys.excepthook```が呼ばれず、errorlog.txtへの書き込みやエラー音の再生が行われません。
そこで、常に```sys.excepthook```が呼ばれるようにするコードを追加しました。

この方法はネットで発見した物ですが、私が過去に作ってきたプログラムでも使用しており、特に問題なく動作しています。