### PR TITLE
ビルド時にbass.dllが拡張子なしでコピーされる問題を修正

### DIFF
--- a/falconSoundPlayer/pybass.py
+++ b/falconSoundPlayer/pybass.py
@@ -61,7 +61,7 @@ if sys.hexversion < 0x02060000:
     ctypes.c_bool = ctypes.c_byte
 
 if platform.system().lower() == 'windows':
-    bass_module = ctypes.WinDLL('bass')
+    bass_module = ctypes.WinDLL('bass.dll')
     func_type = ctypes.WINFUNCTYPE
 else:
     # correct by Wasylews (sabov.97@mail.ru), thank him


### PR DESCRIPTION
ctypes 的には、loadLibraryに拡張子がなくても大丈夫なのだが、pyinstallerは、ライブラリを見つけた後に、ファイル名をloadLibraryの引数と同じにしてコピーしてしまうらしい。
ちなみに、falconはsoundPlayerは使っていなくて、falconSoundPlayer.pybassだけに依存している。(requirementsから消しても良さそう、というか、なんで入ってるんだ)
で、これでdllがコピーできるのは、pyinstaller hookではなく、ctypesからのdllインポートをバイトコード解析で見つけていることによる。
https://pyinstaller.readthedocs.io/en/stable/feature-notes.html
ここでは、 ctypes.utils.find_libraryでdllの絶対パスを得て、そこからコピーするのだけど、コピー先ファイル名にctypes呼び出しの引数をそのまま使ってしまうらしい。